### PR TITLE
EA-3612: fixed bugs with huge files

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -31,6 +31,7 @@ server {
         fastcgi_param SERVER_NAME "OTL";
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
+        fastcgi_read_timeout 3600s;
         include fastcgi_params;
     }
 }

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -42,4 +42,5 @@ RUN go get github.com/mailhog/mhsendmail
 RUN cp /root/go/bin/mhsendmail /usr/bin/mhsendmail
 RUN echo 'sendmail_path = /usr/bin/mhsendmail --smtp-addr mailhog:1025' >> /usr/local/etc/php/php.ini \
     && echo 'upload_max_filesize = 100M' >> /usr/local/etc/php/php.ini \
+    && echo 'max_execution_time = 1200' >> /usr/local/etc/php/php.ini \
     && echo 'post_max_size = 100M' >> /usr/local/etc/php/php.ini

--- a/docker/php-fpm/php-ini-overrides.ini
+++ b/docker/php-fpm/php-ini-overrides.ini
@@ -1,7 +1,7 @@
 upload_max_filesize = 100M
 post_max_size = 108M
 upload_tmp_dir = /tmp
-
+max_execution_time = 1200
 sendmail_path = /usr/bin/mhsendmail --smtp-addr mailhog:1025
 
 

--- a/src/Controller/Command/GenerateUploadToken.php
+++ b/src/Controller/Command/GenerateUploadToken.php
@@ -95,6 +95,7 @@ class GenerateUploadToken implements CommandInterface
         $uploadDAO = new UploadDAO(
             $token,
             0,
+            0,
             $this->maxUploadSize,
             false,
             $this->identifier,

--- a/src/Controller/Command/UploadFile.php
+++ b/src/Controller/Command/UploadFile.php
@@ -122,9 +122,11 @@ class UploadFile implements CommandInterface
 
         if ($chunkNumber <= $totalChunks && $this->storage->writeChunk($hash, $chunkNumber, $payload)) {
             $uploadDAO->setReceivedBytes($receivedBytes);
+            $uploadDAO->setReceivedChunks($uploadDAO->getReceivedChunks() + 1);
             $uploadDAO->save();
             $this->logger->debug("Process upload chunk {$chunkNumber}/{$totalChunks}", ['user' => (string)$this->user]);
-            if ($chunkNumber === $totalChunks) {
+            $this->logger->info("UPLOAD PROGRESS++++:    {$uploadDAO->getReceivedChunks()} - {$totalChunks}");
+            if ($uploadDAO->getReceivedChunks() >= $totalChunks) {
                 $this->logger->info("File upload is done - {$totalChunks} chunks uploaded - Hash {$hash}", ['user' => (string)$this->user]);
                 $this->storage->mergeChunks($hash);
                 $this->logger->info("File upload is done - {$totalChunks} chunks uploaded - Hash {$hash}", ['user' => (string)$this->user]);

--- a/src/DAO/UploadDAO.php
+++ b/src/DAO/UploadDAO.php
@@ -21,6 +21,11 @@ class UploadDAO
     /**
      * @var int
      */
+    private $receivedChunks;
+
+    /**
+     * @var int
+     */
     private $receivedBytes;
 
     /**
@@ -46,6 +51,7 @@ class UploadDAO
     /**
      * UploadDAO constructor.
      * @param $token
+     * @param int $receivedChunks
      * @param int $receivedBytes
      * @param int $maxUploadSize
      * @param bool $done
@@ -54,6 +60,7 @@ class UploadDAO
      */
     public function __construct(
         $token,
+        $receivedChunks,
         $receivedBytes = 0,
         $maxUploadSize = 0,
         bool $done = false,
@@ -61,6 +68,7 @@ class UploadDAO
         string $created = null
     ) {
         $this->token = $token;
+        $this->receivedChunks = $receivedChunks;
         $this->receivedBytes = $receivedBytes;
         $this->maxUploadSize = $maxUploadSize;
         $this->done = $done;
@@ -80,6 +88,7 @@ class UploadDAO
         }
 
         $upload->token = $this->getToken();
+        $upload->receivedChunks = $this->getReceivedChunks();
         $upload->receivedBytes = $this->getReceivedBytes();
         $upload->maxUploadSize = $this->getMaxUploadSize();
         $upload->identifier = $this->getIdentifier();
@@ -91,6 +100,16 @@ class UploadDAO
     public function delete(): void
     {
         R::trash($this->loadDBObject());
+    }
+
+    public function getReceivedChunks(): int
+    {
+        return $this->receivedChunks;
+    }
+
+    public function setReceivedChunks(int $receivedChunks): void
+    {
+        $this->receivedChunks = $receivedChunks;
     }
 
     /**
@@ -214,6 +233,7 @@ class UploadDAO
         if ($upload instanceof OODBBean) {
             return new self(
                 $upload->token,
+                $upload->receivedChunks,
                 $upload->receivedBytes,
                 $upload->maxUploadSize,
                 $upload->done,
@@ -236,6 +256,7 @@ class UploadDAO
         if ($upload instanceof OODBBean) {
             return new self(
                 $upload->token,
+                $upload->receivedChunks,
                 $upload->receivedBytes,
                 $upload->maxUploadSize,
                 $upload->done,

--- a/tests/unit-tests/DAO/UploadDAOTest.php
+++ b/tests/unit-tests/DAO/UploadDAOTest.php
@@ -37,16 +37,18 @@ class UploadDAOTest extends \PHPUnit\Framework\TestCase
         $token = uniqid('token', true);
         $receivedBytes = random_int(100,1000000);
         $maxUploadSize = random_int(100,1000000);
+        $receivedChunks = random_int(100,1000000);
         $done = true;
         $identifier = uniqid('identifier', true);
         $created = uniqid('created', true);
-        $uploadDAO = new UploadDAO($token, $receivedBytes, $maxUploadSize, $done, $identifier, $created);
+        $uploadDAO = new UploadDAO($token, $receivedChunks, $receivedBytes, $maxUploadSize, $done, $identifier, $created);
 
         $this->assertTrue($uploadDAO->save());
 
         $upload = UploadDAO::getUploadFromToken($token);
 
         $this->assertEquals($token, $upload->getToken());
+        $this->assertEquals($receivedChunks, $upload->getReceivedChunks());
         $this->assertEquals($receivedBytes, $upload->getReceivedBytes());
         $this->assertEquals($maxUploadSize, $upload->getMaxUploadSize());
         $this->assertEquals($done, $upload->isDone());
@@ -58,12 +60,14 @@ class UploadDAOTest extends \PHPUnit\Framework\TestCase
         $token = uniqid('token', true);
         $receivedBytes = random_int(100,1000000);
         $maxUploadSize = random_int(100,1000000);
+        $receivedChunks = random_int(100,1000000);
         $done = true;
         $identifier = uniqid('identifier', true);
         $created = uniqid('created', true);
         $uploadDAO = new UploadDAO($token);
 
         $uploadDAO->setToken($token);
+        $uploadDAO->setReceivedChunks($receivedChunks);
         $uploadDAO->setReceivedBytes($receivedBytes);
         $uploadDAO->setMaxUploadSize($maxUploadSize);
         $uploadDAO->setDone($done);
@@ -76,6 +80,7 @@ class UploadDAOTest extends \PHPUnit\Framework\TestCase
         $upload = UploadDAO::getUploadFromIdentifier($identifier);
 
         $this->assertEquals($token, $upload->getToken());
+        $this->assertEquals($receivedChunks, $upload->getReceivedChunks());
         $this->assertEquals($receivedBytes, $upload->getReceivedBytes());
         $this->assertEquals($maxUploadSize, $upload->getMaxUploadSize());
         $this->assertEquals($done, $upload->isDone());
@@ -101,16 +106,18 @@ class UploadDAOTest extends \PHPUnit\Framework\TestCase
         $token = uniqid('token', true);
         $receivedBytes = random_int(100,1000000);
         $maxUploadSize = random_int(100,1000000);
+        $receivedChunks = random_int(100,1000000);
         $done = true;
         $identifier = uniqid('identifier', true);
         $created = uniqid('created', true);
-        $uploadDAO = new UploadDAO($token, $receivedBytes, $maxUploadSize, $done, $identifier, $created);
+        $uploadDAO = new UploadDAO($token, $receivedChunks, $receivedBytes, $maxUploadSize, $done, $identifier, $created);
 
         $this->assertTrue($uploadDAO->save());
 
         $upload = $uploadDAO->loadDBObject();
 
         $this->assertEquals($token, $upload->token);
+        $this->assertEquals($receivedChunks, $upload->receivedChunks);
         $this->assertEquals($receivedBytes, $upload->receivedBytes);
         $this->assertEquals($maxUploadSize, $upload->maxUploadSize);
         $this->assertEquals($done, $upload->done);


### PR DESCRIPTION
Increased fastcgi timeout and PHP max_execution_time.
Additionally, the total number of received chunks is stored in the UploadDAO to facilitate out-of-order chunk transfer.